### PR TITLE
Improved cross-language homogeneity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 ### Changed
+
+- Simplified instanced functions by expecting a named 'handle' method.
+
 ### Deprecated
 ### Removed
 ### Fixed
@@ -19,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [0.2.0] - 2024-11-06
 
 ### Added
+
 - optional message returns from lifeycle methods "alive" and "ready"
 - expanded development and release documentation
 
@@ -26,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [0.1.0] - 2024-10-28
 
 ### Added
+
 - Initial Implementation of the Python HTTP Functions Middleware
 
 

--- a/cmd/fhttp/main.py
+++ b/cmd/fhttp/main.py
@@ -38,9 +38,11 @@ async def handle(scope, receive, send):
 
 # Example instanced handler
 # This is the default expected by this test.
-# The class can be named anything.  See "new" below.
+# The class can be named anything, but there must be a constructor named "new"
+# which returns an object with an async method "handle" conforming to the ASGI
+# callable's method signature.
 class MyFunction:
-    async def __call__(self, scope, receive, send):
+    async def handle(self, scope, receive, send):
         logging.info("OK")
 
         await send({
@@ -68,7 +70,8 @@ class MyFunction:
 
 # Function instance constructor
 # expected to be named exactly "new"
-# Must return a callable which conforms to the ASGI spec.
+# Must return a object which exposes a method "handle" which conforms to the
+# ASGI callable spec.
 def new():
     """ new is the factory function (or constructor) which will create
     a new function instance when invoked.  This must be named "new", and the

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -10,8 +10,10 @@ logging.basicConfig(level=logging.INFO)
 
 # Set a dynamic test URL using an environment variable
 os.environ["LISTEN_ADDRESS"] = os.getenv("LISTEN_ADDRESS", "127.0.0.1:8081")
+
 # Retrieve the LISTEN_ADDRESS for use in the tests
 LISTEN_ADDRESS = os.getenv("LISTEN_ADDRESS")
+
 
 def test_static():
     """
@@ -19,7 +21,7 @@ def test_static():
     style (method signature) is served by the middleware.
     """
 
-    # Functoin
+    # Function
     # An example minimal "static" user function which will be
     # exposed on the network as an ASGI service by the middleware.
     async def handle(scope, receive, send):
@@ -81,7 +83,7 @@ def test_instanced():
     # An example standard "instanced" function (user's Function) which is
     # exposed on the network as an ASGI service by the middleware.
     class MyFunction:
-        async def __call__(self, scope, receive, send):
+        async def handle(self, scope, receive, send):
             await send({
                 'type': 'http.response.start',
                 'status': 200,


### PR DESCRIPTION
## Summary

Use an explicit "handle" method on Function instances, as this is the most similar method signature approach between different language; a primary goal of the project.  This is in contrast to a more strict adherence to the ASGI spec which would see the Function object itself be callable.

## Rationale

Python's __call__ is idiomatically used when the primary purpose of an object is to be callable with a single, well-defined operation. This matches ASGI's design philosophy where handlers are fundamentally single-purpose callables that process requests. However, the Function object also supports additional methods such as readiness/liveness checks, and start/stop event handlers.  Furthermore, the cross-language design goal of Functions suggests having a consistent .handle() method instead.  This approach has has significant benefits:

It makes the code more immediately understandable across language boundaries by maintaining consistency of supported method signatures
It Better communicates intent
It allows for easier automated code generation or translation
It eases ongoing support burden by minimizing language-specific deviations
It maintains consistent mental models across codebases
It makes it clearer that the object is a "handler" rather than just any callable

Using .handle() is not anti-idiomatic, as many frameworks use this method-based approach rather than making objects callable (e.g., Flask class-based views use .dispatch_request()).

This was the original implementation, and after exploring usage of Python functions as an ASGI callable, it is clear the named `handle()` method is better overall.  This PR reverts to that approach.