### PR TITLE
chore: update github cli on publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -67,6 +67,13 @@ jobs:
       contents: write
       id-token: write
     steps:
+    - name: Update GitHub CLI
+      run: |
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        sudo apt update
+        sudo apt install gh -y
+        gh --version
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -125,5 +125,5 @@ jobs:
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/
+        repository-url: https://test.pypi.org/legacy/
 


### PR DESCRIPTION
Actions were failing because the `gh` in ubuntu-latest was behind, resulting in an error as it tried to use a legacy version of the artifact update library which github had since blocked.  This should ensure the latest directly from cli.github.com/packages