### PR TITLE
fix: add SO_REUSEADDR to sock.py to prevent bind failures on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Set SO_REUSEADDR on pre-bound sockets to prevent bind failures on restart
+
 ### Security
 
 ## 0.8.0 - 2026-04-13

--- a/src/func_python/sock.py
+++ b/src/func_python/sock.py
@@ -41,6 +41,7 @@ def bind() -> list[str]:
         else:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind((host, int(port)))
             result.append(f'fd://{sock.detach()}')


### PR DESCRIPTION
add SO_REUSEADDR to sock.py to prevent bind failures on restart (useful for example for e2e tests that run right after one another)