### PR TITLE
Fix: raise soft open-file limit at serve() startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 ### Security
 
+## 0.8.2 - 2026-04-16
+
+### Added
+
+- Automatically raise the soft `RLIMIT_NOFILE` to the hard limit at
+  `serve()` startup, matching Go and Java runtime behaviour. Finite hard
+  limits are honoured in full; when the hard limit is `RLIM_INFINITY` the
+  soft limit is capped at 65536 to stay within kernel constraints.
+  Failures are logged as warnings and never fatal (knative/func#3513).
+
 ## 0.8.1 - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
-
-## 0.8.2 - 2026-04-16
-
-### Added
 
 - Automatically raise the soft `RLIMIT_NOFILE` to the hard limit at
   `serve()` startup, matching Go and Java runtime behaviour. Finite hard
   limits are honoured in full; when the hard limit is `RLIM_INFINITY` the
   soft limit is capped at 65536 to stay within kernel constraints.
   Failures are logged as warnings and never fatal (knative/func#3513).
+
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
 
 ## 0.8.1 - 2026-04-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "func-python"
-version = "0.8.2"
+version = "0.8.1"
 description = "Knative Functions Python Middleware"
 authors = ["The Knative Authors <knative-dev@googlegroups.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "func-python"
-version = "0.8.1"
+version = "0.8.2"
 description = "Knative Functions Python Middleware"
 authors = ["The Knative Authors <knative-dev@googlegroups.com>"]
 readme = "README.md"

--- a/src/func_python/_ulimit.py
+++ b/src/func_python/_ulimit.py
@@ -17,13 +17,15 @@ def _raise_nofile_limit():
     try:
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
         if soft < hard:
-            # RLIM_INFINITY (9223372036854775807 on Linux) cannot be passed
-            # directly to setrlimit — the kernel rejects it with OSError.
-            # Cap the target at a known-safe value instead.
+            # When hard is RLIM_INFINITY the kernel rejects setting the soft
+            # limit to RLIM_INFINITY without CAP_SYS_RESOURCE, so cap the
+            # soft limit at a known-safe value. For finite hard limits, raise
+            # the soft limit all the way to the hard limit as the Go and Java
+            # runtimes do.
             if hard == resource.RLIM_INFINITY:
                 target = _MAX_NOFILE
             else:
-                target = min(hard, _MAX_NOFILE)
+                target = hard
             resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
             logging.info("Raised open-file limit from %d to %d", soft, target)
     except (ValueError, OSError) as e:

--- a/src/func_python/_ulimit.py
+++ b/src/func_python/_ulimit.py
@@ -1,6 +1,16 @@
 import logging
 
+# Module-level import so tests can patch func_python._ulimit._resource directly.
+# On non-Unix platforms (e.g. Windows) the resource module is unavailable;
+# _resource is set to None and _raise_nofile_limit() becomes a no-op.
+try:
+    import resource as _resource
+except ImportError:
+    _resource = None
+
 _MAX_NOFILE = 65536  # safe cap when hard == RLIM_INFINITY
+
+_logger = logging.getLogger(__name__)
 
 
 def _raise_nofile_limit():
@@ -9,24 +19,19 @@ def _raise_nofile_limit():
     Matches the automatic behaviour of the Go and Java runtimes.
     Silently skips on non-Unix platforms where resource is unavailable.
     """
-    try:
-        import resource
-    except ImportError:
+    if _resource is None:
         return  # non-Unix (e.g. Windows) — skip
 
     try:
-        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        soft, hard = _resource.getrlimit(_resource.RLIMIT_NOFILE)
         if soft < hard:
             # When hard is RLIM_INFINITY the kernel rejects setting the soft
             # limit to RLIM_INFINITY without CAP_SYS_RESOURCE, so cap the
             # soft limit at a known-safe value. For finite hard limits, raise
             # the soft limit all the way to the hard limit as the Go and Java
             # runtimes do.
-            if hard == resource.RLIM_INFINITY:
-                target = _MAX_NOFILE
-            else:
-                target = hard
-            resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
-            logging.info("Raised open-file limit from %d to %d", soft, target)
+            target = _MAX_NOFILE if hard == _resource.RLIM_INFINITY else hard
+            _resource.setrlimit(_resource.RLIMIT_NOFILE, (target, hard))
+            _logger.debug("Raised open-file limit from %d to %d", soft, target)
     except (ValueError, OSError) as e:
-        logging.warning("Could not raise open-file limit: %s", e)
+        _logger.warning("Could not raise open-file limit: %s", e)

--- a/src/func_python/_ulimit.py
+++ b/src/func_python/_ulimit.py
@@ -1,0 +1,30 @@
+import logging
+
+_MAX_NOFILE = 65536  # safe cap when hard == RLIM_INFINITY
+
+
+def _raise_nofile_limit():
+    """Raise the process soft open-file limit to the hard limit.
+
+    Matches the automatic behaviour of the Go and Java runtimes.
+    Silently skips on non-Unix platforms where resource is unavailable.
+    """
+    try:
+        import resource
+    except ImportError:
+        return  # non-Unix (e.g. Windows) — skip
+
+    try:
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft < hard:
+            # RLIM_INFINITY (9223372036854775807 on Linux) cannot be passed
+            # directly to setrlimit — the kernel rejects it with OSError.
+            # Cap the target at a known-safe value instead.
+            if hard == resource.RLIM_INFINITY:
+                target = _MAX_NOFILE
+            else:
+                target = min(hard, _MAX_NOFILE)
+            resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+            logging.info("Raised open-file limit from %d to %d", soft, target)
+    except (ValueError, OSError) as e:
+        logging.warning("Could not raise open-file limit: %s", e)

--- a/src/func_python/_ulimit.py
+++ b/src/func_python/_ulimit.py
@@ -24,13 +24,16 @@ def _raise_nofile_limit():
 
     try:
         soft, hard = _resource.getrlimit(_resource.RLIMIT_NOFILE)
-        if soft < hard:
-            # When hard is RLIM_INFINITY the kernel rejects setting the soft
-            # limit to RLIM_INFINITY without CAP_SYS_RESOURCE, so cap the
-            # soft limit at a known-safe value. For finite hard limits, raise
-            # the soft limit all the way to the hard limit as the Go and Java
-            # runtimes do.
-            target = _MAX_NOFILE if hard == _resource.RLIM_INFINITY else hard
+        # When hard is RLIM_INFINITY the kernel rejects setting the soft
+        # limit to RLIM_INFINITY without CAP_SYS_RESOURCE, so cap the
+        # soft limit at a known-safe value. For finite hard limits, raise
+        # the soft limit all the way to the hard limit as the Go and Java
+        # runtimes do.
+        # NOTE: On Linux, RLIM_INFINITY == -1 as a Python int, so comparing
+        # `soft < hard` directly would be False for any positive soft value;
+        # compute the target first and guard on `soft < target` instead.
+        target = _MAX_NOFILE if hard == _resource.RLIM_INFINITY else hard
+        if soft < target:
             _resource.setrlimit(_resource.RLIMIT_NOFILE, (target, hard))
             _logger.debug("Raised open-file limit from %d to %d", soft, target)
     except (ValueError, OSError) as e:

--- a/src/func_python/cloudevent.py
+++ b/src/func_python/cloudevent.py
@@ -13,6 +13,7 @@ from cloudevents.core.bindings.http import (
 from cloudevents.core.exceptions import CloudEventValidationError
 
 import func_python.sock
+from func_python._ulimit import _raise_nofile_limit
 
 DEFAULT_LOG_LEVEL = logging.INFO
 
@@ -24,6 +25,7 @@ def serve(f):
     and starting.  The function can be either a constructor for a functon
     instance (named "new") or a simple ASGI handler function (named "handle").
     """
+    _raise_nofile_limit()
     logging.debug("func runtime creating function instance")
 
     if f.__name__ == 'new':

--- a/src/func_python/http.py
+++ b/src/func_python/http.py
@@ -8,6 +8,7 @@ import hypercorn.config
 import hypercorn.asyncio
 
 import func_python.sock
+from func_python._ulimit import _raise_nofile_limit
 
 DEFAULT_LOG_LEVEL = logging.INFO
 
@@ -19,6 +20,7 @@ def serve(f):
     and starting.  The function can be either a constructor for a functon
     instance (named "new") or a simple ASGI handler function (named "handle").
     """
+    _raise_nofile_limit()
     logging.debug("func runtime creating function instance")
 
     if f.__name__ == 'new':

--- a/tests/test_ulimit.py
+++ b/tests/test_ulimit.py
@@ -1,23 +1,20 @@
 import logging
-import sys
+import resource
 from unittest.mock import MagicMock, patch
 
 
-_RLIM_INFINITY = 9223372036854775807
-
-
-def _make_resource(soft, hard, rlim_infinity=_RLIM_INFINITY):
+def _make_resource(soft, hard, rlim_infinity=None):
     """Build a minimal mock of the resource module."""
-    mock = MagicMock()
-    mock.RLIMIT_NOFILE = 7
-    mock.RLIM_INFINITY = rlim_infinity
+    mock = MagicMock(spec=resource)
+    mock.RLIMIT_NOFILE = resource.RLIMIT_NOFILE
+    mock.RLIM_INFINITY = rlim_infinity if rlim_infinity is not None else resource.RLIM_INFINITY
     mock.getrlimit.return_value = (soft, hard)
     return mock
 
 
 def _call_with_resource(mock_resource):
-    """Call _raise_nofile_limit() with the given resource mock in place."""
-    with patch.dict(sys.modules, {"resource": mock_resource}):
+    """Call _raise_nofile_limit() with the given resource mock patched in place."""
+    with patch("func_python._ulimit._resource", mock_resource):
         from func_python._ulimit import _raise_nofile_limit
         _raise_nofile_limit()
     return mock_resource
@@ -32,7 +29,7 @@ def test_raises_soft_limit_to_hard():
     mock_resource = _make_resource(soft=1024, hard=4096)
     _call_with_resource(mock_resource)
     mock_resource.setrlimit.assert_called_once_with(
-        mock_resource.RLIMIT_NOFILE, (4096, 4096)
+        resource.RLIMIT_NOFILE, (4096, 4096)
     )
 
 
@@ -41,7 +38,7 @@ def test_raises_soft_limit_to_hard_above_65536():
     mock_resource = _make_resource(soft=1024, hard=131072)
     _call_with_resource(mock_resource)
     mock_resource.setrlimit.assert_called_once_with(
-        mock_resource.RLIMIT_NOFILE, (131072, 131072)
+        resource.RLIMIT_NOFILE, (131072, 131072)
     )
 
 
@@ -55,17 +52,18 @@ def test_no_change_when_soft_equals_hard():
 def test_rlim_infinity_capped_at_max():
     """When hard == RLIM_INFINITY the soft limit must be capped at _MAX_NOFILE."""
     from func_python._ulimit import _MAX_NOFILE
-    mock_resource = _make_resource(soft=1024, hard=_RLIM_INFINITY,
-                                   rlim_infinity=_RLIM_INFINITY)
+    rlim_infinity = resource.RLIM_INFINITY
+    mock_resource = _make_resource(soft=1024, hard=rlim_infinity,
+                                   rlim_infinity=rlim_infinity)
     _call_with_resource(mock_resource)
     mock_resource.setrlimit.assert_called_once_with(
-        mock_resource.RLIMIT_NOFILE, (_MAX_NOFILE, _RLIM_INFINITY)
+        resource.RLIMIT_NOFILE, (_MAX_NOFILE, rlim_infinity)
     )
 
 
 def test_import_error_is_silently_skipped():
     """When resource is unavailable (non-Unix), no exception is raised."""
-    with patch.dict(sys.modules, {"resource": None}):
+    with patch("func_python._ulimit._resource", None):
         from func_python._ulimit import _raise_nofile_limit
         _raise_nofile_limit()  # must not raise
 
@@ -74,7 +72,7 @@ def test_os_error_logs_warning(caplog):
     """When setrlimit raises OSError, a warning is logged and no exception propagates."""
     mock_resource = _make_resource(soft=1024, hard=4096)
     mock_resource.setrlimit.side_effect = OSError("operation not permitted")
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING, logger="func_python._ulimit"):
         _call_with_resource(mock_resource)
     assert any("Could not raise open-file limit" in r.message for r in caplog.records)
 
@@ -83,7 +81,7 @@ def test_value_error_logs_warning(caplog):
     """When setrlimit raises ValueError, a warning is logged and no exception propagates."""
     mock_resource = _make_resource(soft=1024, hard=4096)
     mock_resource.setrlimit.side_effect = ValueError("invalid argument")
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING, logger="func_python._ulimit"):
         _call_with_resource(mock_resource)
     assert any("Could not raise open-file limit" in r.message for r in caplog.records)
 

--- a/tests/test_ulimit.py
+++ b/tests/test_ulimit.py
@@ -1,0 +1,106 @@
+import importlib
+import logging
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+
+def _load_ulimit(mock_resource=None):
+    """Import (or reload) _ulimit with an optional resource module mock."""
+    if mock_resource is not None:
+        with patch.dict(sys.modules, {"resource": mock_resource}):
+            import func_python._ulimit as ulimit
+            importlib.reload(ulimit)
+    else:
+        import func_python._ulimit as ulimit
+        importlib.reload(ulimit)
+    return ulimit
+
+
+class TestRaiseNofileLimit(unittest.TestCase):
+
+    def _make_resource(self, soft, hard, rlim_infinity=None):
+        """Build a minimal mock of the resource module."""
+        mock_resource = MagicMock()
+        mock_resource.RLIMIT_NOFILE = 7  # any constant
+        mock_resource.getrlimit.return_value = (soft, hard)
+        mock_resource.RLIM_INFINITY = (
+            rlim_infinity if rlim_infinity is not None else 9223372036854775807
+        )
+        return mock_resource
+
+    def test_raises_soft_limit_to_hard(self):
+        """When soft < hard, setrlimit is called with the target value."""
+        mock_resource = self._make_resource(soft=1024, hard=4096)
+        ulimit = _load_ulimit(mock_resource)
+
+        with patch.dict(sys.modules, {"resource": mock_resource}):
+            ulimit._raise_nofile_limit()
+
+        mock_resource.setrlimit.assert_called_once_with(
+            mock_resource.RLIMIT_NOFILE, (4096, 4096)
+        )
+
+    def test_no_change_when_soft_equals_hard(self):
+        """When soft == hard, setrlimit must not be called."""
+        mock_resource = self._make_resource(soft=4096, hard=4096)
+        ulimit = _load_ulimit(mock_resource)
+
+        with patch.dict(sys.modules, {"resource": mock_resource}):
+            ulimit._raise_nofile_limit()
+
+        mock_resource.setrlimit.assert_not_called()
+
+    def test_rlim_infinity_capped_at_max(self):
+        """When hard == RLIM_INFINITY the target must be capped at _MAX_NOFILE."""
+        RLIM_INFINITY = 9223372036854775807
+        mock_resource = self._make_resource(soft=1024, hard=RLIM_INFINITY,
+                                            rlim_infinity=RLIM_INFINITY)
+        ulimit = _load_ulimit(mock_resource)
+
+        with patch.dict(sys.modules, {"resource": mock_resource}):
+            ulimit._raise_nofile_limit()
+
+        mock_resource.setrlimit.assert_called_once_with(
+            mock_resource.RLIMIT_NOFILE, (ulimit._MAX_NOFILE, RLIM_INFINITY)
+        )
+
+    def test_import_error_is_silently_skipped(self):
+        """When resource is unavailable (non-Unix), no exception is raised."""
+        with patch.dict(sys.modules, {"resource": None}):
+            import func_python._ulimit as ulimit
+            importlib.reload(ulimit)
+            # Should complete without raising anything
+            ulimit._raise_nofile_limit()
+
+    def test_os_error_logs_warning(self, caplog=None):
+        """When setrlimit raises OSError, a warning is logged and no exception propagates."""
+        mock_resource = self._make_resource(soft=1024, hard=4096)
+        mock_resource.setrlimit.side_effect = OSError("operation not permitted")
+        ulimit = _load_ulimit(mock_resource)
+
+        with patch.dict(sys.modules, {"resource": mock_resource}):
+            with self.assertLogs(level=logging.WARNING) as log_ctx:
+                ulimit._raise_nofile_limit()
+
+        self.assertTrue(
+            any("Could not raise open-file limit" in msg for msg in log_ctx.output)
+        )
+
+    def test_value_error_logs_warning(self):
+        """When setrlimit raises ValueError, a warning is logged and no exception propagates."""
+        mock_resource = self._make_resource(soft=1024, hard=4096)
+        mock_resource.setrlimit.side_effect = ValueError("invalid argument")
+        ulimit = _load_ulimit(mock_resource)
+
+        with patch.dict(sys.modules, {"resource": mock_resource}):
+            with self.assertLogs(level=logging.WARNING) as log_ctx:
+                ulimit._raise_nofile_limit()
+
+        self.assertTrue(
+            any("Could not raise open-file limit" in msg for msg in log_ctx.output)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ulimit.py
+++ b/tests/test_ulimit.py
@@ -1,106 +1,122 @@
-import importlib
 import logging
 import sys
-import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 
-def _load_ulimit(mock_resource=None):
-    """Import (or reload) _ulimit with an optional resource module mock."""
-    if mock_resource is not None:
-        with patch.dict(sys.modules, {"resource": mock_resource}):
-            import func_python._ulimit as ulimit
-            importlib.reload(ulimit)
-    else:
-        import func_python._ulimit as ulimit
-        importlib.reload(ulimit)
-    return ulimit
+_RLIM_INFINITY = 9223372036854775807
 
 
-class TestRaiseNofileLimit(unittest.TestCase):
-
-    def _make_resource(self, soft, hard, rlim_infinity=None):
-        """Build a minimal mock of the resource module."""
-        mock_resource = MagicMock()
-        mock_resource.RLIMIT_NOFILE = 7  # any constant
-        mock_resource.getrlimit.return_value = (soft, hard)
-        mock_resource.RLIM_INFINITY = (
-            rlim_infinity if rlim_infinity is not None else 9223372036854775807
-        )
-        return mock_resource
-
-    def test_raises_soft_limit_to_hard(self):
-        """When soft < hard, setrlimit is called with the target value."""
-        mock_resource = self._make_resource(soft=1024, hard=4096)
-        ulimit = _load_ulimit(mock_resource)
-
-        with patch.dict(sys.modules, {"resource": mock_resource}):
-            ulimit._raise_nofile_limit()
-
-        mock_resource.setrlimit.assert_called_once_with(
-            mock_resource.RLIMIT_NOFILE, (4096, 4096)
-        )
-
-    def test_no_change_when_soft_equals_hard(self):
-        """When soft == hard, setrlimit must not be called."""
-        mock_resource = self._make_resource(soft=4096, hard=4096)
-        ulimit = _load_ulimit(mock_resource)
-
-        with patch.dict(sys.modules, {"resource": mock_resource}):
-            ulimit._raise_nofile_limit()
-
-        mock_resource.setrlimit.assert_not_called()
-
-    def test_rlim_infinity_capped_at_max(self):
-        """When hard == RLIM_INFINITY the target must be capped at _MAX_NOFILE."""
-        RLIM_INFINITY = 9223372036854775807
-        mock_resource = self._make_resource(soft=1024, hard=RLIM_INFINITY,
-                                            rlim_infinity=RLIM_INFINITY)
-        ulimit = _load_ulimit(mock_resource)
-
-        with patch.dict(sys.modules, {"resource": mock_resource}):
-            ulimit._raise_nofile_limit()
-
-        mock_resource.setrlimit.assert_called_once_with(
-            mock_resource.RLIMIT_NOFILE, (ulimit._MAX_NOFILE, RLIM_INFINITY)
-        )
-
-    def test_import_error_is_silently_skipped(self):
-        """When resource is unavailable (non-Unix), no exception is raised."""
-        with patch.dict(sys.modules, {"resource": None}):
-            import func_python._ulimit as ulimit
-            importlib.reload(ulimit)
-            # Should complete without raising anything
-            ulimit._raise_nofile_limit()
-
-    def test_os_error_logs_warning(self, caplog=None):
-        """When setrlimit raises OSError, a warning is logged and no exception propagates."""
-        mock_resource = self._make_resource(soft=1024, hard=4096)
-        mock_resource.setrlimit.side_effect = OSError("operation not permitted")
-        ulimit = _load_ulimit(mock_resource)
-
-        with patch.dict(sys.modules, {"resource": mock_resource}):
-            with self.assertLogs(level=logging.WARNING) as log_ctx:
-                ulimit._raise_nofile_limit()
-
-        self.assertTrue(
-            any("Could not raise open-file limit" in msg for msg in log_ctx.output)
-        )
-
-    def test_value_error_logs_warning(self):
-        """When setrlimit raises ValueError, a warning is logged and no exception propagates."""
-        mock_resource = self._make_resource(soft=1024, hard=4096)
-        mock_resource.setrlimit.side_effect = ValueError("invalid argument")
-        ulimit = _load_ulimit(mock_resource)
-
-        with patch.dict(sys.modules, {"resource": mock_resource}):
-            with self.assertLogs(level=logging.WARNING) as log_ctx:
-                ulimit._raise_nofile_limit()
-
-        self.assertTrue(
-            any("Could not raise open-file limit" in msg for msg in log_ctx.output)
-        )
+def _make_resource(soft, hard, rlim_infinity=_RLIM_INFINITY):
+    """Build a minimal mock of the resource module."""
+    mock = MagicMock()
+    mock.RLIMIT_NOFILE = 7
+    mock.RLIM_INFINITY = rlim_infinity
+    mock.getrlimit.return_value = (soft, hard)
+    return mock
 
 
-if __name__ == "__main__":
-    unittest.main()
+def _call_with_resource(mock_resource):
+    """Call _raise_nofile_limit() with the given resource mock in place."""
+    with patch.dict(sys.modules, {"resource": mock_resource}):
+        from func_python._ulimit import _raise_nofile_limit
+        _raise_nofile_limit()
+    return mock_resource
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _raise_nofile_limit()
+# ---------------------------------------------------------------------------
+
+def test_raises_soft_limit_to_hard():
+    """When soft < hard (finite), setrlimit is called with the full hard value."""
+    mock_resource = _make_resource(soft=1024, hard=4096)
+    _call_with_resource(mock_resource)
+    mock_resource.setrlimit.assert_called_once_with(
+        mock_resource.RLIMIT_NOFILE, (4096, 4096)
+    )
+
+
+def test_raises_soft_limit_to_hard_above_65536():
+    """Hard limits above 65536 must be honoured in full, not capped."""
+    mock_resource = _make_resource(soft=1024, hard=131072)
+    _call_with_resource(mock_resource)
+    mock_resource.setrlimit.assert_called_once_with(
+        mock_resource.RLIMIT_NOFILE, (131072, 131072)
+    )
+
+
+def test_no_change_when_soft_equals_hard():
+    """When soft == hard, setrlimit must not be called."""
+    mock_resource = _make_resource(soft=4096, hard=4096)
+    _call_with_resource(mock_resource)
+    mock_resource.setrlimit.assert_not_called()
+
+
+def test_rlim_infinity_capped_at_max():
+    """When hard == RLIM_INFINITY the soft limit must be capped at _MAX_NOFILE."""
+    from func_python._ulimit import _MAX_NOFILE
+    mock_resource = _make_resource(soft=1024, hard=_RLIM_INFINITY,
+                                   rlim_infinity=_RLIM_INFINITY)
+    _call_with_resource(mock_resource)
+    mock_resource.setrlimit.assert_called_once_with(
+        mock_resource.RLIMIT_NOFILE, (_MAX_NOFILE, _RLIM_INFINITY)
+    )
+
+
+def test_import_error_is_silently_skipped():
+    """When resource is unavailable (non-Unix), no exception is raised."""
+    with patch.dict(sys.modules, {"resource": None}):
+        from func_python._ulimit import _raise_nofile_limit
+        _raise_nofile_limit()  # must not raise
+
+
+def test_os_error_logs_warning(caplog):
+    """When setrlimit raises OSError, a warning is logged and no exception propagates."""
+    mock_resource = _make_resource(soft=1024, hard=4096)
+    mock_resource.setrlimit.side_effect = OSError("operation not permitted")
+    with caplog.at_level(logging.WARNING):
+        _call_with_resource(mock_resource)
+    assert any("Could not raise open-file limit" in r.message for r in caplog.records)
+
+
+def test_value_error_logs_warning(caplog):
+    """When setrlimit raises ValueError, a warning is logged and no exception propagates."""
+    mock_resource = _make_resource(soft=1024, hard=4096)
+    mock_resource.setrlimit.side_effect = ValueError("invalid argument")
+    with caplog.at_level(logging.WARNING):
+        _call_with_resource(mock_resource)
+    assert any("Could not raise open-file limit" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Wire-up tests: verify serve() in http.py and cloudevent.py call the helper
+# ---------------------------------------------------------------------------
+
+def test_http_serve_calls_raise_nofile_limit():
+    """serve() in http.py must call _raise_nofile_limit() before doing anything else."""
+    with patch("func_python.http._raise_nofile_limit") as mock_fn:
+        with patch("func_python.http.ASGIApplication") as mock_app:
+            mock_app.return_value.serve.return_value = None
+            from func_python.http import serve
+
+            async def handle(scope, receive, send):
+                pass
+
+            serve(handle)
+
+    mock_fn.assert_called_once()
+
+
+def test_cloudevent_serve_calls_raise_nofile_limit():
+    """serve() in cloudevent.py must call _raise_nofile_limit() before doing anything else."""
+    with patch("func_python.cloudevent._raise_nofile_limit") as mock_fn:
+        with patch("func_python.cloudevent.ASGIApplication") as mock_app:
+            mock_app.return_value.serve.return_value = None
+            from func_python.cloudevent import serve
+
+            async def handle(scope, receive, send):
+                pass
+
+            serve(handle)
+
+    mock_fn.assert_called_once()


### PR DESCRIPTION
## Problem

Python functions fail under load on container platforms that set a low
soft open-file limit (e.g. 1024). The Go and Java runtimes raise the
soft limit to the hard limit automatically at startup; Python does not.

Relates to knative/func#3513

## Solution

Add `_raise_nofile_limit()` in a new `src/func_python/_ulimit.py`
module and call it at the very top of `serve()` in both `http.py` and
`cloudevent.py`. Placing the fix in the library means every deployed
function benefits from a single version bump, rather than requiring a
rebuild of every container image.

The implementation:

- For finite hard limits: raises the soft `RLIMIT_NOFILE` to the hard
  limit exactly, matching Go and Java runtime behaviour.
- For `RLIM_INFINITY` hard limits: caps the soft limit at `_MAX_NOFILE`
  (65536) because the kernel rejects setting the soft limit to
  `RLIM_INFINITY` without `CAP_SYS_RESOURCE`.
- Silently skips on non-Unix platforms where `resource` is unavailable
  (`_resource = None` at module level).
- Logs a `DEBUG` message on success and a `WARNING` on failure via a
  named logger (`logging.getLogger(__name__)`), but never raises — a
  failure to adjust the limit is not a fatal error.

## Changes

- `src/func_python/_ulimit.py` — new shared helper
- `src/func_python/http.py` — import and call `_raise_nofile_limit()` at top of `serve()`
- `src/func_python/cloudevent.py` — same
- `tests/test_ulimit.py` — nine unit tests using `patch("func_python._ulimit._resource")` for guaranteed mock isolation
- `pyproject.toml` — version bumped to 0.8.2
- `CHANGELOG.md` — entry added under 0.8.2

## Test plan

- `test_raises_soft_limit_to_hard` — soft < hard (finite ≤ 65536), `setrlimit` called with full hard value
- `test_raises_soft_limit_to_hard_above_65536` — hard = 131072, `setrlimit` called with 131072 (not capped)
- `test_no_change_when_soft_equals_hard` — `setrlimit` not called
- `test_rlim_infinity_capped_at_max` — hard is `RLIM_INFINITY`, target is `_MAX_NOFILE`
- `test_import_error_is_silently_skipped` — `_resource = None`, no exception
- `test_os_error_logs_warning` — `setrlimit` raises `OSError`, warning logged, no exception
- `test_value_error_logs_warning` — `setrlimit` raises `ValueError`, warning logged, no exception
- `test_http_serve_calls_raise_nofile_limit` — wire-up verified for `http.serve()`
- `test_cloudevent_serve_calls_raise_nofile_limit` — wire-up verified for `cloudevent.serve()`

All nine tests pass (`poetry run pytest tests/test_ulimit.py -v`).