### PR TITLE
fix: Fail on start() instead of silent ignore; encode string during error returns

### DIFF
--- a/src/func_python/cloudevent.py
+++ b/src/func_python/cloudevent.py
@@ -114,7 +114,13 @@ class ASGIApplication():
             while True:
                 message = await receive()
                 if message['type'] == 'lifespan.startup':
-                    await self.on_start()
+                    try:
+                        await self.on_start()
+                    except Exception as e:
+                        logging.error("function startup failed: %s", e)
+                        await send({'type': 'lifespan.startup.failed',
+                                    'message': str(e)})
+                        return
                     await send({'type': 'lifespan.startup.complete'})
                 elif message['type'] == 'lifespan.shutdown':
                     await self.on_stop()
@@ -253,7 +259,7 @@ async def send_exception(send, code, message):
         'headers': [[b'content-type', b'text/plain']],
     })
     await send({
-        'type': 'http.response.body', 'body': message,
+        'type': 'http.response.body', 'body': message.encode('utf-8') if isinstance(message, str) else message,
     })
 
 

--- a/src/func_python/http.py
+++ b/src/func_python/http.py
@@ -107,7 +107,13 @@ class ASGIApplication():
             while True:
                 message = await receive()
                 if message['type'] == 'lifespan.startup':
-                    await self.on_start()
+                    try:
+                        await self.on_start()
+                    except Exception as e:
+                        logging.error("function startup failed: %s", e)
+                        await send({'type': 'lifespan.startup.failed',
+                                    'message': str(e)})
+                        return
                     await send({'type': 'lifespan.startup.complete'})
                 elif message['type'] == 'lifespan.shutdown':
                     await self.on_stop()
@@ -186,5 +192,5 @@ async def send_exception(send, code, message):
         'headers': [[b'content-type', b'text/plain']],
     })
     await send({
-        'type': 'http.response.body', 'body': message,
+        'type': 'http.response.body', 'body': message.encode('utf-8') if isinstance(message, str) else message,
     })


### PR DESCRIPTION
## add try/except wrapper for start() method to error on failed start; encode strings to bytes in exception returns


## observed errors:
 
### silent fail on start()
Lifespan failure — hypercorn silently continues with broken state:
```
INFO:root:Functions middleware invoking user function
[2026-05-06 07:40:51 +0200] [219186] [WARNING] ASGI Framework Lifespan error, continuing without
Lifespan support
WARNING:hypercorn.error:ASGI Framework Lifespan error, continuing without Lifespan support
[2026-05-06 07:40:51 +0200] [219186] [INFO] Running on http://127.0.0.1:8080 (CTRL + C to quit)
INFO:hypercorn.error:Running on http://127.0.0.1:8080 (CTRL + C to quit)
```
this will appear to run the function just fine (for a second) and then `Error: timed out waiting for function to be ready for 1m0s` BUT the function is still listening! 

on curl you get
```
[2026-05-06 09:57:21 +0200] [648316] [ERROR] Error in ASGI Framework
Traceback (most recent call last):
  File ".../func_python/http.py", line 134, in __call__
    await self.f.handle(scope, receive, send)
  File ".../function/func.py", line 85, in handle
    "database": self.db.db_path,
                ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'db_path'
```

### exception error
```
  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File ".../func_python/http.py", line 136, in __call__
      await send_exception(send, 500, f"Error: {e}")
    File ".../func_python/http.py", line 188, in send_exception
      await send({
          'type': 'http.response.body', 'body': message,
      })
    File ".../hypercorn/protocol/http_stream.py", line 193, in app_send
      Body(stream_id=self.stream_id, data=bytes(message.get("body", b"")))
                                          ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  TypeError: string argument without an encoding
```

